### PR TITLE
DOC: add instructions for installing development version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ pip install "numpy>=2.4"
 pip install numpy-quaddtype
 ```
 
+Or grab the development version with
+
+```bash
+pip install git+https://github.com/numpy/numpy-quaddtype.git
+```
+
 ## Usage
 
 ```python


### PR DESCRIPTION
Since the current version on pypi doesn't work, and the package is still changing, it may be useful for people to be told how to get the development version (it is something I always have to look up...).