### PR TITLE
CI: Adding CI to test old CPU for SIMD compatibility via SDE Emulation

### DIFF
--- a/.github/workflows/test_old_cpu.yml
+++ b/.github/workflows/test_old_cpu.yml
@@ -16,6 +16,7 @@ jobs:
     name: Test on ${{ matrix.cpu[1] }}
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         cpu:
           - ['snb', 'Sandy Bridge (x86_64-v2)']


### PR DESCRIPTION
This workflow emulates the SandyBridge (x86-64-v2) and Haswell (x86-64-v3)
And similar to #56 we can reproduce the failure because of unrecognized instruction in SandyBridge