### PR TITLE
Pre-import numpy lazy submodules before running tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import numpy
+
+for _attr in (
+    "linalg", "fft", "dtypes", "random", "polynomial", "ma",
+    "ctypeslib", "exceptions", "testing", "matlib", "f2py",
+    "typing", "rec", "char", "core", "strings",
+):
+    getattr(numpy, _attr)
+del _attr

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,9 @@
+# Pre-import numpy's lazy submodules in single-threaded context before
+# pytest-run-parallel forks workers. Works around CPython issue https://github.com/python/cpython/issues/149728 
+# which causes numpy's lazy __getattr__ on rec/ma/linalg/fft/... to recurse
+# to RecursionError under concurrent first-touch from multiple threads.
+# Drop this file when CPython bugfix release happens.
+
 import numpy
 
 for _attr in (


### PR DESCRIPTION
Workaround for an upstream CPython bug exposed by our free-threaded CI on `cp3.14t`.

## Why

Our free-threaded CI on `python3.14t` started failing in `test_pandas_strrep` with a `RecursionError` whose entire stack was inside `numpy/__init__.py`'s lazy `__getattr__` recursing on `import numpy.rec as rec`. Root cause is a race in CPython's `importlib._bootstrap`: `_load_unlocked` clears `spec._initializing = False` before `_find_and_load_unlocked` runs `setattr(parent_module, child, module)`, so the fast path in `_find_and_load` returns the module without the parent attribute under that window. Under free-threaded preemption a second thread reliably observes the window, falls into numpy's lazy `__getattr__`, runs `import numpy.rec as rec` again, fast-paths again, and recurses.

Upstream tracking:

- CPython issue: https://github.com/python/cpython/issues/149728
- CPython PR (fixes the race): https://github.com/python/cpython/pull/149729

Original failure traceback in this project's CI: https://github.com/numpy/numpy-quaddtype/pull/88#issuecomment-4426320213
