### PR TITLE
ci: declare contents:read on test_old_cpu workflow

### DIFF
--- a/.github/workflows/test_old_cpu.yml
+++ b/.github/workflows/test_old_cpu.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test_old_cpu:
     name: Test on ${{ matrix.cpu[1] }}


### PR DESCRIPTION
The `Test on Older CPUs (x86_64-v2)` workflow runs an Intel SDE-emulated test matrix against Sandy Bridge and Haswell baselines. It only checks out, downloads SDE, installs system deps, and runs the test suite under emulation. No GitHub API write, no comment-on-PR step.

This patch pins it to `permissions: contents: read` at workflow scope, matching the per-job block in `build_wheels.yml` (`id-token: write` for trusted publishing) and the workflow-level shape used by `big_endian.yml`, `build_docs.yml`, and `typecheck.yml`.

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file

No behavioural change.