### PR TITLE
BUG: Avoid binary64 intermediates in long-double/SLEEF casts

### DIFF
--- a/src/csrc/casts.cpp
+++ b/src/csrc/casts.cpp
@@ -15,6 +15,9 @@ extern "C" {
 }
 #include <cstring>
 #include <cstdlib>
+#include <cfloat>
+#include <cfenv>
+#include <limits>
 #include <type_traits>
 #include "sleef.h"
 #include "sleefquad.h"
@@ -51,6 +54,153 @@ Total: 46 characters, using 50 as a safe buffer
 static inline const char *
 quad_to_string_adaptive_cstr(Sleef_quad *sleef_val, npy_intp unicode_size_chars);
 
+static inline void
+cast_longdouble_to_sleef(long double value, Sleef_quad *out)
+{
+    static_assert(FLT_RADIX == 2, "Quad backend conversion requires a binary long double");
+    static_assert(LDBL_MANT_DIG == 53 || LDBL_MANT_DIG == 64 || LDBL_MANT_DIG == 113,
+                  "unsupported long double significand format");
+    static_assert(LDBL_MIN_EXP >= -16381 && LDBL_MAX_EXP <= 16384,
+                  "long double range exceeds the SLEEF binary128 backend");
+
+    Sleef_quad result;
+    if (std::isnan(value)) {
+        result = std::signbit(value) ? QUAD_PRECISION_NEG_NAN : QUAD_PRECISION_NAN;
+        memcpy(out, &result, sizeof(result));
+        return;
+    }
+    if (std::isinf(value)) {
+        result = value < 0 ? QUAD_PRECISION_NINF : QUAD_PRECISION_INF;
+        memcpy(out, &result, sizeof(result));
+        return;
+    }
+    if (value == 0.0L) {
+        result = std::signbit(value) ? Sleef_negq1(QUAD_PRECISION_ZERO) : QUAD_PRECISION_ZERO;
+        memcpy(out, &result, sizeof(result));
+        return;
+    }
+
+#if defined(SLEEF_LONGDOUBLE_IS_IEEEQP)
+    static_assert(sizeof(Sleef_quad) == sizeof(long double));
+    memcpy(out, &value, sizeof(value));
+    return;
+#elif defined(SLEEF_FLOAT128_IS_IEEEQP)
+    result = static_cast<Sleef_quad>(value);
+    memcpy(out, &result, sizeof(result));
+    return;
+#elif LDBL_MANT_DIG == DBL_MANT_DIG && LDBL_MAX_EXP == DBL_MAX_EXP
+    result = Sleef_cast_from_doubleq1((double)value);
+    memcpy(out, &result, sizeof(result));
+    return;
+#endif
+
+    bool negative = std::signbit(value);
+    int exponent;
+    long double fraction = std::frexp(std::fabs(value), &exponent);
+    Sleef_quad significand = QUAD_PRECISION_ZERO;
+
+    int remaining = LDBL_MANT_DIG;
+    while (remaining > 0) {
+        int chunk_bits = remaining > 32 ? 32 : remaining;
+        long double scaled = std::ldexp(fraction, chunk_bits);
+        int64_t chunk = (int64_t)std::floor(scaled);
+        fraction = scaled - (long double)chunk;
+        significand = Sleef_addq1_u05(Sleef_ldexpq1(significand, chunk_bits),
+                                      Sleef_cast_from_int64q1(chunk));
+        remaining -= chunk_bits;
+    }
+
+    result = Sleef_ldexpq1(significand, exponent - LDBL_MANT_DIG);
+    if (negative) {
+        result = Sleef_negq1(result);
+    }
+    memcpy(out, &result, sizeof(result));
+}
+
+static inline long double
+cast_sleef_to_longdouble(Sleef_quad value)
+{
+    static_assert(FLT_RADIX == 2, "Quad backend conversion requires a binary long double");
+    static_assert(LDBL_MANT_DIG == 53 || LDBL_MANT_DIG == 64 || LDBL_MANT_DIG == 113,
+                  "unsupported long double significand format");
+    static_assert(LDBL_MIN_EXP >= -16381 && LDBL_MAX_EXP <= 16384,
+                  "long double range exceeds the SLEEF binary128 backend");
+
+    bool negative = quad_signbit(&value);
+    if (quad_isnan(&value)) {
+        long double result = std::numeric_limits<long double>::quiet_NaN();
+        return std::copysign(result, negative ? -1.0L : 1.0L);
+    }
+    if (quad_isinf(&value)) {
+        long double result = std::numeric_limits<long double>::infinity();
+        return negative ? -result : result;
+    }
+    if (Sleef_icmpeqq1(value, QUAD_PRECISION_ZERO)) {
+        return negative ? -0.0L : 0.0L;
+    }
+
+#if defined(SLEEF_LONGDOUBLE_IS_IEEEQP)
+    static_assert(sizeof(Sleef_quad) == sizeof(long double));
+    long double native;
+    memcpy(&native, &value, sizeof(native));
+    return native;
+#elif defined(SLEEF_FLOAT128_IS_IEEEQP)
+    return static_cast<long double>(value);
+#elif LDBL_MANT_DIG == DBL_MANT_DIG && LDBL_MAX_EXP == DBL_MAX_EXP
+    return (long double)Sleef_cast_to_doubleq1(value);
+#endif
+
+    Sleef_quad magnitude = Sleef_fabsq1(value);
+    int exponent;
+    Sleef_frexpq1(magnitude, &exponent);
+    // C defines LDBL_MIN_EXP so min normal is 2**(LDBL_MIN_EXP - 1);
+    // therefore the smallest subnormal quantum is 2**(LDBL_MIN_EXP - p).
+    int quantum_exponent =
+            exponent >= LDBL_MIN_EXP ? exponent - LDBL_MANT_DIG : LDBL_MIN_EXP - LDBL_MANT_DIG;
+
+    Sleef_quad scaled = Sleef_ldexpq1(magnitude, -quantum_exponent);
+    Sleef_quad rounded_units;
+    switch (std::fegetround()) {
+        case FE_DOWNWARD:
+            rounded_units = negative ? Sleef_ceilq1(scaled) : Sleef_floorq1(scaled);
+            break;
+        case FE_UPWARD:
+            rounded_units = negative ? Sleef_floorq1(scaled) : Sleef_ceilq1(scaled);
+            break;
+        case FE_TOWARDZERO:
+            rounded_units = Sleef_floorq1(scaled);
+            break;
+        case FE_TONEAREST:
+        default:
+            rounded_units = quad_rint(&scaled);
+            break;
+    }
+    Sleef_quad rounded = Sleef_ldexpq1(rounded_units, quantum_exponent);
+    if (quad_isinf(&rounded)) {
+        long double result = std::numeric_limits<long double>::infinity();
+        return negative ? -result : result;
+    }
+    if (Sleef_icmpeqq1(rounded, QUAD_PRECISION_ZERO)) {
+        return negative ? -0.0L : 0.0L;
+    }
+
+    Sleef_quad fraction = Sleef_frexpq1(rounded, &exponent);
+    long double significand = 0.0L;
+    int remaining = LDBL_MANT_DIG;
+    while (remaining > 0) {
+        int chunk_bits = remaining > 32 ? 32 : remaining;
+        Sleef_quad chunk_source = Sleef_ldexpq1(fraction, chunk_bits);
+        Sleef_quad chunk_integer = Sleef_truncq1(chunk_source);
+        int64_t chunk = Sleef_cast_to_int64q1(chunk_integer);
+        fraction = Sleef_subq1_u05(chunk_source, chunk_integer);
+        significand = std::ldexp(significand, chunk_bits) + (long double)chunk;
+        remaining -= chunk_bits;
+    }
+
+    long double result = std::ldexp(significand, exponent - LDBL_MANT_DIG);
+    return negative ? -result : result;
+}
+
 static NPY_CASTING
 quad_to_quad_resolve_descriptors(PyObject *NPY_UNUSED(self),
                                  PyArray_DTypeMeta *NPY_UNUSED(dtypes[2]),
@@ -86,8 +236,6 @@ quad_to_quad_resolve_descriptors(PyObject *NPY_UNUSED(self),
 }
 
 // Helper function for quad-to-quad same_value check (inter-backend)
-// NOTE: the inter-backend uses `double` as intermediate,
-// so only values that can be exactly represented in double can pass same_value check
 static inline int
 quad_to_quad_same_value_check(const quad_value *in_val, QuadBackendType backend_in,
                               const quad_value *out_val, QuadBackendType backend_out)
@@ -107,8 +255,7 @@ quad_to_quad_same_value_check(const quad_value *in_val, QuadBackendType backend_
             roundtrip.sleef_value = (ld > 0) ? QUAD_PRECISION_INF : QUAD_PRECISION_NINF;
         }
         else {
-            Sleef_quad temp = Sleef_cast_from_doubleq1(static_cast<double>(ld));
-            memcpy(&roundtrip.sleef_value, &temp, sizeof(Sleef_quad));
+            cast_longdouble_to_sleef(ld, &roundtrip.sleef_value);
         }
         
         // Compare in SLEEF domain && signbit preserved
@@ -121,8 +268,8 @@ quad_to_quad_same_value_check(const quad_value *in_val, QuadBackendType backend_
     else {
         // Input was longdouble, output is SLEEF
         // Convert SLEEF back to longdouble for comparison
-        roundtrip.longdouble_value = static_cast<long double>(cast_sleef_to_double(out_val->sleef_value));
-        
+        roundtrip.longdouble_value = cast_sleef_to_longdouble(out_val->sleef_value);
+
         // Compare in longdouble domain && signbit preserved
         bool is_sign_preserved = (ld_signbit(&in_val->longdouble_value) == ld_signbit(&roundtrip.longdouble_value));
         if ((std::isnan(in_val->longdouble_value) && std::isnan(roundtrip.longdouble_value)) && is_sign_preserved)
@@ -168,24 +315,12 @@ quad_to_quad_strided_loop(PyArrayMethod_Context *context, char *const data[],
             quad_value out_val;
             if (backend_in == BACKEND_SLEEF) 
             {
-              out_val.longdouble_value = static_cast<long double>(cast_sleef_to_double(in_val.sleef_value));
+                out_val.longdouble_value = cast_sleef_to_longdouble(in_val.sleef_value);
             }
             else 
             {
               long double ld = in_val.longdouble_value;
-              if (std::isnan(ld)) {
-                  out_val.sleef_value = (!ld_signbit(&ld)) ? QUAD_PRECISION_NAN : QUAD_PRECISION_NEG_NAN;
-              }
-              else if (std::isinf(ld)) {
-                  out_val.sleef_value = (ld > 0) ? QUAD_PRECISION_INF : QUAD_PRECISION_NINF;
-              }
-              else 
-              {
-                  // to prevent compiler optimizations, ABI handling issues with __float128 on x86-64 machines
-                  // won't be expensive as for fixed size compiler can optimize memcpy with movq
-                  Sleef_quad temp = Sleef_cast_from_doubleq1(static_cast<double>(ld));
-                  std::memcpy(&out_val.sleef_value, &temp, sizeof(Sleef_quad));
-              }
+              cast_longdouble_to_sleef(ld, &out_val.sleef_value);
             }
             
             // check same_value for inter-backend casts
@@ -1141,16 +1276,7 @@ to_quad<long double>(long double x, QuadBackendType backend)
     quad_value result;
     if (backend == BACKEND_SLEEF) 
     {
-      if (std::isnan(x)) {
-          result.sleef_value = std::signbit(x) ? QUAD_PRECISION_NEG_NAN : QUAD_PRECISION_NAN;
-      }
-      else if (std::isinf(x)) {
-          result.sleef_value = (x > 0) ? QUAD_PRECISION_INF : QUAD_PRECISION_NINF;
-      }
-      else {
-          Sleef_quad temp = Sleef_cast_from_doubleq1(static_cast<double>(x));
-          std::memcpy(&result.sleef_value, &temp, sizeof(Sleef_quad));
-      }
+        cast_longdouble_to_sleef(x, &result.sleef_value);
     }
     else {
         result.longdouble_value = x;
@@ -1426,7 +1552,7 @@ inline long double
 from_quad<long double>(const quad_value *x, QuadBackendType backend)
 {
     if (backend == BACKEND_SLEEF) {
-        return (long double)cast_sleef_to_double(x->sleef_value);
+        return cast_sleef_to_longdouble(x->sleef_value);
     }
     else {
         return x->longdouble_value;

--- a/src/csrc/casts.cpp
+++ b/src/csrc/casts.cpp
@@ -54,12 +54,64 @@ Total: 46 characters, using 50 as a safe buffer
 static inline const char *
 quad_to_string_adaptive_cstr(Sleef_quad *sleef_val, npy_intp unicode_size_chars);
 
+enum QuadRoundingMode {
+    QUAD_ROUND_NEAREST,
+    QUAD_ROUND_DOWN,
+    QUAD_ROUND_UP,
+    QUAD_ROUND_ZERO,
+};
+
+static inline QuadRoundingMode
+quad_get_rounding_mode()
+{
+#ifdef _MSC_VER
+    unsigned int control;
+    if (_controlfp_s(&control, 0, 0) != 0) {
+        return QUAD_ROUND_NEAREST;
+    }
+    switch (control & _MCW_RC) {
+        case _RC_DOWN:
+            return QUAD_ROUND_DOWN;
+        case _RC_UP:
+            return QUAD_ROUND_UP;
+        case _RC_CHOP:
+            return QUAD_ROUND_ZERO;
+        case _RC_NEAR:
+        default:
+            return QUAD_ROUND_NEAREST;
+    }
+#else
+    switch (std::fegetround()) {
+        case FE_DOWNWARD:
+            return QUAD_ROUND_DOWN;
+        case FE_UPWARD:
+            return QUAD_ROUND_UP;
+        case FE_TOWARDZERO:
+            return QUAD_ROUND_ZERO;
+        case FE_TONEAREST:
+        default:
+            return QUAD_ROUND_NEAREST;
+    }
+#endif
+}
+
+template <typename Float>
+static inline Float
+cast_overflow_result(bool negative)
+{
+    QuadRoundingMode mode = quad_get_rounding_mode();
+    bool to_infinity = mode == QUAD_ROUND_NEAREST || (mode == QUAD_ROUND_UP && !negative) ||
+                       (mode == QUAD_ROUND_DOWN && negative);
+    Float magnitude = to_infinity ? std::numeric_limits<Float>::infinity()
+                                  : std::numeric_limits<Float>::max();
+    return negative ? -magnitude : magnitude;
+}
+
 static inline void
 cast_longdouble_to_sleef(long double value, Sleef_quad *out)
 {
     static_assert(FLT_RADIX == 2, "Quad backend conversion requires a binary long double");
-    static_assert(LDBL_MANT_DIG == 53 || LDBL_MANT_DIG == 64 || LDBL_MANT_DIG == 113,
-                  "unsupported long double significand format");
+    static_assert(LDBL_MANT_DIG <= 113, "long double is wider than the SLEEF binary128 backend");
     static_assert(LDBL_MIN_EXP >= -16381 && LDBL_MAX_EXP <= 16384,
                   "long double range exceeds the SLEEF binary128 backend");
 
@@ -89,9 +141,13 @@ cast_longdouble_to_sleef(long double value, Sleef_quad *out)
     memcpy(out, &result, sizeof(result));
     return;
 #elif LDBL_MANT_DIG == DBL_MANT_DIG && LDBL_MAX_EXP == DBL_MAX_EXP
+    // Widening binary64 to binary128 is exact.
     result = Sleef_cast_from_doubleq1((double)value);
     memcpy(out, &result, sizeof(result));
     return;
+#else
+    static_assert(LDBL_MANT_DIG == 64,
+                  "unsupported long double format for the portable conversion path");
 #endif
 
     bool negative = std::signbit(value);
@@ -117,28 +173,90 @@ cast_longdouble_to_sleef(long double value, Sleef_quad *out)
     memcpy(out, &result, sizeof(result));
 }
 
-static inline long double
-cast_sleef_to_longdouble(Sleef_quad value)
+template <typename Float>
+static inline Float
+cast_sleef_to_binary(Sleef_quad value)
 {
+    constexpr int mantissa_digits = std::numeric_limits<Float>::digits;
+    constexpr int min_exponent = std::numeric_limits<Float>::min_exponent;
+    constexpr int max_exponent = std::numeric_limits<Float>::max_exponent;
     static_assert(FLT_RADIX == 2, "Quad backend conversion requires a binary long double");
-    static_assert(LDBL_MANT_DIG == 53 || LDBL_MANT_DIG == 64 || LDBL_MANT_DIG == 113,
-                  "unsupported long double significand format");
-    static_assert(LDBL_MIN_EXP >= -16381 && LDBL_MAX_EXP <= 16384,
-                  "long double range exceeds the SLEEF binary128 backend");
+    static_assert(std::numeric_limits<Float>::radix == 2,
+                  "target floating-point type must use radix 2");
+    static_assert(mantissa_digits <= 113,
+                  "target floating-point type is wider than SLEEF binary128");
+    static_assert(min_exponent >= -16381 && max_exponent <= 16384,
+                  "target floating-point range exceeds SLEEF binary128");
 
     bool negative = quad_signbit(&value);
     if (quad_isnan(&value)) {
-        long double result = std::numeric_limits<long double>::quiet_NaN();
-        return std::copysign(result, negative ? -1.0L : 1.0L);
+        Float result = std::numeric_limits<Float>::quiet_NaN();
+        return std::copysign(result, negative ? (Float)-1 : (Float)1);
     }
     if (quad_isinf(&value)) {
-        long double result = std::numeric_limits<long double>::infinity();
+        Float result = std::numeric_limits<Float>::infinity();
         return negative ? -result : result;
     }
     if (Sleef_icmpeqq1(value, QUAD_PRECISION_ZERO)) {
+        return negative ? (Float)-0.0 : (Float)0.0;
+    }
+
+    Sleef_quad magnitude = Sleef_fabsq1(value);
+    int exponent;
+    Sleef_frexpq1(magnitude, &exponent);
+    // min_exponent follows C's convention: min normal is 2**(min_exponent - 1).
+    int quantum_exponent =
+            exponent >= min_exponent ? exponent - mantissa_digits : min_exponent - mantissa_digits;
+
+    Sleef_quad scaled = Sleef_ldexpq1(magnitude, -quantum_exponent);
+    Sleef_quad rounded_units;
+    switch (quad_get_rounding_mode()) {
+        case QUAD_ROUND_DOWN:
+            rounded_units = negative ? Sleef_ceilq1(scaled) : Sleef_floorq1(scaled);
+            break;
+        case QUAD_ROUND_UP:
+            rounded_units = negative ? Sleef_floorq1(scaled) : Sleef_ceilq1(scaled);
+            break;
+        case QUAD_ROUND_ZERO:
+            rounded_units = Sleef_floorq1(scaled);
+            break;
+        case QUAD_ROUND_NEAREST:
+        default:
+            rounded_units = quad_rint(&scaled);
+            break;
+    }
+    Sleef_quad rounded = Sleef_ldexpq1(rounded_units, quantum_exponent);
+    if (quad_isinf(&rounded)) {
+        return cast_overflow_result<Float>(negative);
+    }
+    if (Sleef_icmpeqq1(rounded, QUAD_PRECISION_ZERO)) {
         return negative ? -0.0L : 0.0L;
     }
 
+    Sleef_quad fraction = Sleef_frexpq1(rounded, &exponent);
+    if (exponent > max_exponent) {
+        return cast_overflow_result<Float>(negative);
+    }
+
+    Float significand = 0;
+    int remaining = mantissa_digits;
+    while (remaining > 0) {
+        int chunk_bits = remaining > 32 ? 32 : remaining;
+        Sleef_quad chunk_source = Sleef_ldexpq1(fraction, chunk_bits);
+        Sleef_quad chunk_integer = Sleef_truncq1(chunk_source);
+        int64_t chunk = Sleef_cast_to_int64q1(chunk_integer);
+        fraction = Sleef_subq1_u05(chunk_source, chunk_integer);
+        significand = std::ldexp(significand, chunk_bits) + (Float)chunk;
+        remaining -= chunk_bits;
+    }
+
+    Float result = std::ldexp(significand, exponent - mantissa_digits);
+    return negative ? -result : result;
+}
+
+static inline long double
+cast_sleef_to_longdouble(Sleef_quad value)
+{
 #if defined(SLEEF_LONGDOUBLE_IS_IEEEQP)
     static_assert(sizeof(Sleef_quad) == sizeof(long double));
     long double native;
@@ -146,59 +264,13 @@ cast_sleef_to_longdouble(Sleef_quad value)
     return native;
 #elif defined(SLEEF_FLOAT128_IS_IEEEQP)
     return static_cast<long double>(value);
-#elif LDBL_MANT_DIG == DBL_MANT_DIG && LDBL_MAX_EXP == DBL_MAX_EXP
-    return (long double)Sleef_cast_to_doubleq1(value);
+#else
+    static_assert(LDBL_MANT_DIG == 53 || LDBL_MANT_DIG == 64,
+                  "unsupported long double format for the portable conversion path");
+    // Do not use Sleef_cast_to_doubleq1 for p=53: it is not correctly rounded
+    // at binary64 midpoint neighbors on all SLEEF backends (notably macOS ARM).
+    return cast_sleef_to_binary<long double>(value);
 #endif
-
-    Sleef_quad magnitude = Sleef_fabsq1(value);
-    int exponent;
-    Sleef_frexpq1(magnitude, &exponent);
-    // C defines LDBL_MIN_EXP so min normal is 2**(LDBL_MIN_EXP - 1);
-    // therefore the smallest subnormal quantum is 2**(LDBL_MIN_EXP - p).
-    int quantum_exponent =
-            exponent >= LDBL_MIN_EXP ? exponent - LDBL_MANT_DIG : LDBL_MIN_EXP - LDBL_MANT_DIG;
-
-    Sleef_quad scaled = Sleef_ldexpq1(magnitude, -quantum_exponent);
-    Sleef_quad rounded_units;
-    switch (std::fegetround()) {
-        case FE_DOWNWARD:
-            rounded_units = negative ? Sleef_ceilq1(scaled) : Sleef_floorq1(scaled);
-            break;
-        case FE_UPWARD:
-            rounded_units = negative ? Sleef_floorq1(scaled) : Sleef_ceilq1(scaled);
-            break;
-        case FE_TOWARDZERO:
-            rounded_units = Sleef_floorq1(scaled);
-            break;
-        case FE_TONEAREST:
-        default:
-            rounded_units = quad_rint(&scaled);
-            break;
-    }
-    Sleef_quad rounded = Sleef_ldexpq1(rounded_units, quantum_exponent);
-    if (quad_isinf(&rounded)) {
-        long double result = std::numeric_limits<long double>::infinity();
-        return negative ? -result : result;
-    }
-    if (Sleef_icmpeqq1(rounded, QUAD_PRECISION_ZERO)) {
-        return negative ? -0.0L : 0.0L;
-    }
-
-    Sleef_quad fraction = Sleef_frexpq1(rounded, &exponent);
-    long double significand = 0.0L;
-    int remaining = LDBL_MANT_DIG;
-    while (remaining > 0) {
-        int chunk_bits = remaining > 32 ? 32 : remaining;
-        Sleef_quad chunk_source = Sleef_ldexpq1(fraction, chunk_bits);
-        Sleef_quad chunk_integer = Sleef_truncq1(chunk_source);
-        int64_t chunk = Sleef_cast_to_int64q1(chunk_integer);
-        fraction = Sleef_subq1_u05(chunk_source, chunk_integer);
-        significand = std::ldexp(significand, chunk_bits) + (long double)chunk;
-        remaining -= chunk_bits;
-    }
-
-    long double result = std::ldexp(significand, exponent - LDBL_MANT_DIG);
-    return negative ? -result : result;
 }
 
 static NPY_CASTING
@@ -1540,7 +1612,7 @@ inline double
 from_quad<double>(const quad_value *x, QuadBackendType backend)
 {
     if (backend == BACKEND_SLEEF) {
-        return cast_sleef_to_double(x->sleef_value);
+        return cast_sleef_to_binary<double>(x->sleef_value);
     }
     else {
         return (double)x->longdouble_value;

--- a/tests/test_inter_backend_casts.py
+++ b/tests/test_inter_backend_casts.py
@@ -39,10 +39,19 @@ def _as_longdouble(value, target=LONGDOUBLE):
     return value.astype(target).astype(np.longdouble)[0]
 
 
+def _as_float64(value):
+    return value.astype(np.float64)[0]
+
+
 def _assert_value_and_sign(actual, expected):
     assert actual == expected
     if actual == 0:
         assert np.signbit(actual) == np.signbit(expected)
+
+
+def _require_narrower_longdouble():
+    if LD_INFO.nmant >= 112:
+        pytest.skip("long double has the same precision as SLEEF binary128")
 
 
 @contextlib.contextmanager
@@ -72,7 +81,18 @@ def _rounding_mode(name):
     libc = ctypes.CDLL(None)
     if not hasattr(libc, "fegetround") or not hasattr(libc, "fesetround"):
         pytest.skip("floating-point environment API is unavailable")
-    values = {"nearest": 0, "down": 0x400, "up": 0x800, "zero": 0xC00}
+    libc.fegetround.restype = ctypes.c_int
+    libc.fesetround.argtypes = [ctypes.c_int]
+    libc.fesetround.restype = ctypes.c_int
+    if machine in {"aarch64", "arm64"}:
+        values = {
+            "nearest": 0,
+            "down": 0x800000,
+            "up": 0x400000,
+            "zero": 0xC00000,
+        }
+    else:
+        values = {"nearest": 0, "down": 0x400, "up": 0x800, "zero": 0xC00}
     previous = libc.fegetround()
     assert libc.fesetround(values[name]) == 0
     try:
@@ -192,6 +212,7 @@ def test_longdouble_to_sleef_random_exact_roundtrip(casting):
 
 @pytest.mark.parametrize("mode", ROUNDING_MODES)
 def test_sleef_to_longdouble_rounding_modes(mode):
+    _require_narrower_longdouble()
     one = np.array(["1"], dtype=SLEEF)
     next_up = np.nextafter(np.longdouble(1), np.longdouble(2), dtype=np.longdouble)
     next_down = np.nextafter(np.longdouble(-1), np.longdouble(-2), dtype=np.longdouble)
@@ -217,6 +238,7 @@ def test_sleef_to_longdouble_rounding_modes(mode):
 
 @pytest.mark.parametrize("mode", ROUNDING_MODES)
 def test_sleef_to_longdouble_underflow_and_overflow_modes(mode):
+    _require_narrower_longdouble()
     one = np.array(["1"], dtype=SLEEF)
     zero = np.longdouble(0)
     min_subnormal = np.nextafter(zero, np.longdouble(1), dtype=np.longdouble)
@@ -244,6 +266,97 @@ def test_sleef_to_longdouble_underflow_and_overflow_modes(mode):
         _assert_value_and_sign(result, wanted)
 
 
+@pytest.mark.parametrize("mode", ROUNDING_MODES)
+def test_sleef_to_float64_rounding_modes(mode):
+    one = np.array(["1"], dtype=SLEEF)
+    next_up = np.nextafter(np.float64(1), np.float64(2))
+    next_down = np.nextafter(np.float64(-1), np.float64(-2))
+    upper = np.array([next_up], dtype=np.float64).astype(SLEEF)
+    lower_negative = np.array([next_down], dtype=np.float64).astype(SLEEF)
+    positive_midpoint = (one + upper) / np.array(["2"], dtype=SLEEF)
+    negative_midpoint = (-one + lower_negative) / np.array(["2"], dtype=SLEEF)
+    expected = {
+        "nearest": (np.float64(1), np.float64(-1)),
+        "down": (np.float64(1), next_down),
+        "up": (next_up, np.float64(-1)),
+        "zero": (np.float64(1), np.float64(-1)),
+    }
+
+    with _rounding_mode(mode):
+        actual = (_as_float64(positive_midpoint), _as_float64(negative_midpoint))
+
+    for result, wanted in zip(actual, expected[mode], strict=True):
+        _assert_value_and_sign(result, wanted)
+
+
+@pytest.mark.parametrize("mode", ROUNDING_MODES)
+def test_sleef_to_float64_underflow_and_overflow_modes(mode):
+    info = np.finfo(np.float64)
+    precision = info.nmant + 1
+    one = np.array(["1"], dtype=SLEEF)
+    zero = np.float64(0)
+    min_subnormal = np.nextafter(zero, np.float64(1))
+    half_min_subnormal = np.ldexp(one, info.minexp - precision)
+    max_value = np.array([info.max], dtype=np.float64).astype(SLEEF)
+    overflow_midpoint = max_value + np.ldexp(one, info.maxexp - precision - 1)
+    far_overflow = np.array(["1e4000"], dtype=SLEEF)
+    expected = {
+        "nearest": (
+            zero,
+            -zero,
+            np.float64("inf"),
+            np.float64("-inf"),
+            np.float64("inf"),
+            np.float64("-inf"),
+        ),
+        "down": (
+            zero,
+            -min_subnormal,
+            info.max,
+            np.float64("-inf"),
+            info.max,
+            np.float64("-inf"),
+        ),
+        "up": (
+            min_subnormal,
+            -zero,
+            np.float64("inf"),
+            -info.max,
+            np.float64("inf"),
+            -info.max,
+        ),
+        "zero": (zero, -zero, info.max, -info.max, info.max, -info.max),
+    }
+
+    with _rounding_mode(mode), np.errstate(over="ignore", under="ignore"):
+        actual = (
+            _as_float64(half_min_subnormal),
+            _as_float64(-half_min_subnormal),
+            _as_float64(overflow_midpoint),
+            _as_float64(-overflow_midpoint),
+            _as_float64(far_overflow),
+            _as_float64(-far_overflow),
+        )
+
+    for result, wanted in zip(actual, expected[mode], strict=True):
+        _assert_value_and_sign(result, wanted)
+
+
+@pytest.mark.parametrize("exponent", [-1020, -100, -1, 0, 1, 100, 1022])
+@pytest.mark.parametrize("sign", [1, -1])
+def test_sleef_to_float64_adjacent_midpoints_across_exponents(exponent, sign):
+    value = np.ldexp(np.float64("0.75"), exponent)
+    value = value if sign > 0 else -value
+    direction = np.float64("inf") if sign > 0 else np.float64("-inf")
+    neighbor = np.nextafter(value, direction)
+    lower = np.array([value], dtype=np.float64).astype(SLEEF)
+    upper = np.array([neighbor], dtype=np.float64).astype(SLEEF)
+    midpoint = (lower + upper) / np.array(["2"], dtype=SLEEF)
+
+    assert _as_float64(np.nextafter(midpoint, lower)) == value
+    assert _as_float64(np.nextafter(midpoint, upper)) == neighbor
+
+
 @pytest.mark.parametrize(
     "exponent",
     [
@@ -258,6 +371,7 @@ def test_sleef_to_longdouble_underflow_and_overflow_modes(mode):
 )
 @pytest.mark.parametrize("sign", [1, -1])
 def test_sleef_to_longdouble_adjacent_midpoints_across_exponents(exponent, sign):
+    _require_narrower_longdouble()
     value = np.ldexp(np.longdouble("0.75"), exponent)
     value = value if sign > 0 else -value
     direction = np.longdouble("inf") if sign > 0 else np.longdouble("-inf")

--- a/tests/test_inter_backend_casts.py
+++ b/tests/test_inter_backend_casts.py
@@ -1,0 +1,315 @@
+import contextlib
+import ctypes
+import platform
+import random
+
+import numpy as np
+import pytest
+
+from numpy_quaddtype import QuadPrecDType
+
+
+SLEEF = QuadPrecDType(backend="sleef")
+LONGDOUBLE = QuadPrecDType(backend="longdouble")
+LD_INFO = np.finfo(np.longdouble)
+LD_PRECISION = LD_INFO.nmant + 1
+
+BEYOND_DOUBLE = [
+    "9007199254740993",
+    "1.000000000000000000867361737988403547205962240695953369140625",
+]
+SPECIAL_VALUES = ["0", "-0", "inf", "-inf", "nan", "-nan"]
+BACKEND_CASTS = [
+    pytest.param("longdouble", "sleef", "safe", id="longdouble-to-sleef"),
+    pytest.param("sleef", "longdouble", "same_kind", id="sleef-to-longdouble"),
+]
+ROUNDING_MODES = [
+    pytest.param("nearest", id="nearest-even"),
+    pytest.param("down", id="downward"),
+    pytest.param("up", id="upward"),
+    pytest.param("zero", id="toward-zero"),
+]
+
+
+def _dtype(backend):
+    return QuadPrecDType(backend=backend)
+
+
+def _as_longdouble(value, target=LONGDOUBLE):
+    return value.astype(target).astype(np.longdouble)[0]
+
+
+def _assert_value_and_sign(actual, expected):
+    assert actual == expected
+    if actual == 0:
+        assert np.signbit(actual) == np.signbit(expected)
+
+
+@contextlib.contextmanager
+def _rounding_mode(name):
+    system = platform.system()
+    machine = platform.machine().lower()
+    if system == "Windows":
+        control = ctypes.CDLL("msvcrt")._controlfp_s
+        current = ctypes.c_uint()
+        control(ctypes.byref(current), 0, 0)
+        values = {"nearest": 0, "down": 0x100, "up": 0x200, "zero": 0x300}
+        control(ctypes.byref(ctypes.c_uint()), values[name], 0x300)
+        try:
+            yield
+        finally:
+            control(ctypes.byref(ctypes.c_uint()), current.value, 0x300)
+        return
+
+    if system not in {"Linux", "Darwin"} or machine not in {
+        "x86_64",
+        "amd64",
+        "aarch64",
+        "arm64",
+    }:
+        pytest.skip("rounding-mode constants are unknown on this platform")
+
+    libc = ctypes.CDLL(None)
+    if not hasattr(libc, "fegetround") or not hasattr(libc, "fesetround"):
+        pytest.skip("floating-point environment API is unavailable")
+    values = {"nearest": 0, "down": 0x400, "up": 0x800, "zero": 0xC00}
+    previous = libc.fegetround()
+    assert libc.fesetround(values[name]) == 0
+    try:
+        yield
+    finally:
+        assert libc.fesetround(previous) == 0
+
+
+@pytest.mark.parametrize("value", BEYOND_DOUBLE)
+@pytest.mark.parametrize("source_kind", ["quad", "numpy"])
+def test_longdouble_to_sleef_preserves_values_beyond_double(value, source_kind):
+    if LD_INFO.nmant <= np.finfo(np.float64).nmant:
+        pytest.skip("long double has no precision beyond double")
+
+    source = (
+        np.array([value], dtype=LONGDOUBLE)
+        if source_kind == "quad"
+        else np.array([np.longdouble(value)], dtype=np.longdouble)
+    )
+    expected = np.array([value], dtype=SLEEF)
+
+    result = source.astype(SLEEF, casting="safe")
+
+    np.testing.assert_array_equal(result, expected, strict=True)
+
+
+@pytest.mark.parametrize("value", BEYOND_DOUBLE)
+def test_longdouble_to_sleef_same_value_beyond_double(value):
+    if LD_INFO.nmant <= np.finfo(np.float64).nmant:
+        pytest.skip("long double has no precision beyond double")
+
+    source = np.array([value], dtype=LONGDOUBLE)
+    expected = np.array([value], dtype=SLEEF)
+
+    result = source.astype(SLEEF, casting="same_value")
+
+    np.testing.assert_array_equal(result, expected, strict=True)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            "1.000000000000000000867361737988403547205962240695953369140625",
+            "1.000000000000000000867361737988403547205962240695953369140625",
+        ),
+        (
+            "1.0000000000000000000542101086242752217003726400434970855712890625",
+            "1.0",
+        ),
+        (
+            "1.0000000000000000001626303258728256651011179201304912567138671875",
+            "1.00000000000000000021684043449710088680149056017398834228515625",
+        ),
+    ],
+)
+@pytest.mark.parametrize("target_kind", ["quad", "numpy"])
+def test_sleef_to_x87_rounds_once_to_nearest_even(source, expected, target_kind):
+    if LD_INFO.nmant != 63:
+        pytest.skip("test values target x87 64-bit significand rounding")
+
+    value = np.array([source], dtype=SLEEF)
+    if target_kind == "quad":
+        result = value.astype(LONGDOUBLE).astype(np.longdouble)
+    else:
+        result = value.astype(np.longdouble)
+    expected_array = np.array([np.longdouble(expected)], dtype=np.longdouble)
+
+    np.testing.assert_array_equal(result, expected_array, strict=True)
+
+
+@pytest.mark.parametrize("value", SPECIAL_VALUES)
+@pytest.mark.parametrize(("source_backend", "target_backend", "_"), BACKEND_CASTS)
+def test_inter_backend_special_values_preserve_class_and_sign(
+    value, source_backend, target_backend, _
+):
+    source = np.array([value], dtype=_dtype(source_backend))
+
+    result = source.astype(_dtype(target_backend))
+
+    assert np.signbit(result[0]) == np.signbit(source[0])
+    if "nan" in value:
+        assert np.isnan(result[0])
+    elif "inf" in value:
+        assert np.isinf(result[0])
+    else:
+        assert float(result[0]) == float(source[0]) == 0.0
+
+
+@pytest.mark.parametrize("casting", ["safe", "same_value"])
+def test_longdouble_to_sleef_random_exact_roundtrip(casting):
+    rng = random.Random(1847)
+    values = [
+        np.longdouble(0),
+        np.longdouble("-0"),
+        LD_INFO.max,
+        -LD_INFO.max,
+        LD_INFO.tiny,
+        -LD_INFO.tiny,
+        np.nextafter(np.longdouble(0), np.longdouble(1), dtype=np.longdouble),
+    ]
+    for _ in range(256):
+        significand = (1 << (LD_PRECISION - 1)) | rng.getrandbits(LD_PRECISION - 1)
+        exponent = rng.randint(LD_INFO.minexp, LD_INFO.maxexp - 1)
+        value = np.ldexp(np.longdouble(str(significand)), exponent - LD_PRECISION)
+        values.append(-value if rng.getrandbits(1) else value)
+
+    original = np.array(values, dtype=np.longdouble)
+    source = original.astype(LONGDOUBLE)
+    widened = source.astype(SLEEF, casting=casting)
+    roundtrip = widened.astype(LONGDOUBLE, casting="same_value")
+    actual = roundtrip.astype(np.longdouble)
+
+    np.testing.assert_array_equal(actual, original, strict=True)
+    np.testing.assert_array_equal(np.signbit(actual), np.signbit(original))
+
+
+@pytest.mark.parametrize("mode", ROUNDING_MODES)
+def test_sleef_to_longdouble_rounding_modes(mode):
+    one = np.array(["1"], dtype=SLEEF)
+    next_up = np.nextafter(np.longdouble(1), np.longdouble(2), dtype=np.longdouble)
+    next_down = np.nextafter(np.longdouble(-1), np.longdouble(-2), dtype=np.longdouble)
+    upper = np.array([next_up], dtype=np.longdouble).astype(LONGDOUBLE).astype(SLEEF)
+    lower_negative = (
+        np.array([next_down], dtype=np.longdouble).astype(LONGDOUBLE).astype(SLEEF)
+    )
+    positive_midpoint = (one + upper) / np.array(["2"], dtype=SLEEF)
+    negative_midpoint = (-one + lower_negative) / np.array(["2"], dtype=SLEEF)
+    expected = {
+        "nearest": (np.longdouble(1), np.longdouble(-1)),
+        "down": (np.longdouble(1), next_down),
+        "up": (next_up, np.longdouble(-1)),
+        "zero": (np.longdouble(1), np.longdouble(-1)),
+    }
+
+    with _rounding_mode(mode):
+        actual = (_as_longdouble(positive_midpoint), _as_longdouble(negative_midpoint))
+
+    for result, wanted in zip(actual, expected[mode], strict=True):
+        _assert_value_and_sign(result, wanted)
+
+
+@pytest.mark.parametrize("mode", ROUNDING_MODES)
+def test_sleef_to_longdouble_underflow_and_overflow_modes(mode):
+    one = np.array(["1"], dtype=SLEEF)
+    zero = np.longdouble(0)
+    min_subnormal = np.nextafter(zero, np.longdouble(1), dtype=np.longdouble)
+    half_min_subnormal = np.ldexp(one, LD_INFO.minexp - LD_PRECISION)
+    max_value = (
+        np.array([LD_INFO.max], dtype=np.longdouble).astype(LONGDOUBLE).astype(SLEEF)
+    )
+    overflow_midpoint = max_value + np.ldexp(one, LD_INFO.maxexp - LD_PRECISION - 1)
+    expected = {
+        "nearest": (zero, -zero, np.longdouble("inf"), np.longdouble("-inf")),
+        "down": (zero, -min_subnormal, LD_INFO.max, np.longdouble("-inf")),
+        "up": (min_subnormal, -zero, np.longdouble("inf"), -LD_INFO.max),
+        "zero": (zero, -zero, LD_INFO.max, -LD_INFO.max),
+    }
+
+    with _rounding_mode(mode), np.errstate(over="ignore", under="ignore"):
+        actual = (
+            _as_longdouble(half_min_subnormal),
+            _as_longdouble(-half_min_subnormal),
+            _as_longdouble(overflow_midpoint),
+            _as_longdouble(-overflow_midpoint),
+        )
+
+    for result, wanted in zip(actual, expected[mode], strict=True):
+        _assert_value_and_sign(result, wanted)
+
+
+@pytest.mark.parametrize(
+    "exponent",
+    [
+        LD_INFO.minexp + 2,
+        -1000,
+        -1,
+        0,
+        1,
+        1000,
+        LD_INFO.maxexp - 2,
+    ],
+)
+@pytest.mark.parametrize("sign", [1, -1])
+def test_sleef_to_longdouble_adjacent_midpoints_across_exponents(exponent, sign):
+    value = np.ldexp(np.longdouble("0.75"), exponent)
+    value = value if sign > 0 else -value
+    direction = np.longdouble("inf") if sign > 0 else np.longdouble("-inf")
+    neighbor = np.nextafter(value, direction, dtype=np.longdouble)
+    lower = np.array([value], dtype=np.longdouble).astype(LONGDOUBLE).astype(SLEEF)
+    upper = np.array([neighbor], dtype=np.longdouble).astype(LONGDOUBLE).astype(SLEEF)
+    midpoint = (lower + upper) / np.array(["2"], dtype=SLEEF)
+
+    toward_value = np.nextafter(midpoint, lower)
+    toward_neighbor = np.nextafter(midpoint, upper)
+
+    assert _as_longdouble(toward_value) == value
+    assert _as_longdouble(toward_neighbor) == neighbor
+
+
+@pytest.mark.parametrize(("source_backend", "target_backend", "casting"), BACKEND_CASTS)
+@pytest.mark.parametrize("shape", [(0,), (17,), (3, 4), (2, 3, 5)])
+@pytest.mark.parametrize("layout", ["contiguous", "reversed", "unaligned"])
+def test_inter_backend_casts_support_shapes_and_strides(
+    source_backend, target_backend, casting, shape, layout
+):
+    source_dtype = _dtype(source_backend)
+    target_dtype = _dtype(target_backend)
+    count = int(np.prod(shape))
+    values = np.linspace(-100, 100, count, dtype=np.longdouble).reshape(shape)
+    aligned = values.astype(source_dtype)
+
+    if layout == "contiguous":
+        source = aligned
+        expected_source = aligned
+        result = source.astype(target_dtype, casting=casting)
+    elif layout == "reversed":
+        source = aligned[..., ::-1]
+        expected_source = source
+        result = source.astype(target_dtype, casting=casting)
+    else:
+        source = np.ndarray(
+            shape,
+            dtype=source_dtype,
+            buffer=bytearray(1 + count * source_dtype.itemsize),
+            offset=1,
+        )
+        target = np.ndarray(
+            shape,
+            dtype=target_dtype,
+            buffer=bytearray(1 + count * target_dtype.itemsize),
+            offset=1,
+        )
+        source[...] = aligned
+        expected_source = aligned
+        np.copyto(target, source, casting=casting)
+        result = target
+
+    expected = expected_source.astype(target_dtype, casting=casting)
+    np.testing.assert_array_equal(result, expected, strict=True)

--- a/tests/test_quaddtype.py
+++ b/tests/test_quaddtype.py
@@ -6248,8 +6248,7 @@ class TestSameValueCasting:
     ])
     def test_quad_to_quad_same_value_casting_passing(self, src_backend, dst_backend):
         """Test values that should roundtrip exactly between backends."""
-        # Values exactly representable in both backends (and in double, since
-        # inter-backend conversion goes through double)
+        # Values exactly representable in both backends.
         passing_values = [
             0.0, -0.0, 1.0, -1.0,
             0.5, 0.25, 0.125,
@@ -6268,44 +6267,32 @@ class TestSameValueCasting:
             if val in ["nan", "-nan"] :
                 assert np.isnan(result[0])
             else:
-                # compare them as float, as these values anyhow have to under double's range to work
-                assert float(result[0]) == float(src[0]), f"Value {val} failed for {src_backend} -> {dst_backend}"
+                roundtrip = result.astype(
+                    QuadPrecDType(backend=src_backend), casting="same_value"
+                )
+                assert roundtrip[0] == src[0], f"Value {val} failed for {src_backend} -> {dst_backend}"
 
 
-    @pytest.mark.parametrize("src_backend,dst_backend", [
-        ("sleef", "longdouble"),
-        ("longdouble", "sleef"),
-    ])
-    def test_quad_to_quad_interbackend_same_value_casting_failing(self, src_backend, dst_backend):
+    def test_quad_to_quad_interbackend_same_value_casting_failing(self):
         """Test values that cannot roundtrip exactly between backends.
-        
-        Inter-backend conversion goes through double, so values exceeding
-        double's precision (~53 bits mantissa) will fail same_value casting.
+
+        SLEEF binary128 values with more precision than the platform long
+        double must fail same_value casting.
         """
         ld_info = np.finfo(np.longdouble)
-        double_info = np.finfo(np.float64)
-        
-        # Skip if longdouble has same precision as quad (PowerPC binary128)
-        # In that case, sleef <-> longdouble might use a direct path
+
         if ld_info.nmant >= 112:
             pytest.skip("longdouble has same precision as quad on this platform")
-        
-        # For longdouble -> sleef: only fails if longdouble has more precision than double
-        if src_backend == "longdouble" and ld_info.nmant <= double_info.nmant:
-            pytest.skip("longdouble has same or less precision than double on this platform")
-        
-        # Values that exceed double precision (53-bit mantissa)
-        # These will lose precision when going through the double conversion
+
         failing_values = [
-            str(2**53 + 1),  # First integer not exactly representable in double
             "3.141592653589793238462643383279502884197",  # Pi with more than double precision
-            "1.00000000000000011",  # 1 + epsilon beyond double precision
+            "1.0000000000000000000000000000000001",
         ]
-        
+
         for val in failing_values:
-            src = np.array([val], dtype=QuadPrecDType(backend=src_backend))
+            src = np.array([val], dtype=QuadPrecDType(backend="sleef"))
             with pytest.raises(ValueError):
-                src.astype(QuadPrecDType(backend=dst_backend), casting="same_value")
+                src.astype(QuadPrecDType(backend="longdouble"), casting="same_value")
 
 
     @pytest.mark.parametrize("backend", ["sleef", "longdouble"])


### PR DESCRIPTION
Closes #112.

This PR implements direct conversion in both directions:

- `long double -> SLEEF` is exact.
- `SLEEF -> long double` is correctly rounded to the target format under the active IEEE rounding mode.

The same implementation is used for:

- `QuadPrecDType` inter-backend casts
- NumPy `longdouble -> SLEEF QuadPrecDType`
- SLEEF `QuadPrecDType -> NumPy longdouble`
- `casting="same_value"` roundtrip checks

## Widening: long double -> SLEEF

The conversion selects the cheapest exact path available:

- Native IEEE binary128 long double: direct representation copy
- Native `__float128`: direct compiler widening
- `long double == double`: SLEEF's direct binary64 conversion
- Portable fallback: exact radix-2 reconstruction in 32-bit significand chunks

The portable path uses `frexp` to decompose the source value and reconstructs its complete significand in binary128. Every intermediate is exactly representable, so no additional rounding occurs.

For example, these values now retain their bits:

```python
np.longdouble("9007199254740993")
np.longdouble("1.000000000000000000867361737988403547...")
```

## Narrowing: SLEEF -> long double

The portable path rounds binary128 directly to the target long-double format:

1. Determine the target quantum for normal or subnormal values.
2. Scale the binary128 value to integer quantum units.
3. Round once according to the active floating-point rounding mode.
4. Reconstruct the rounded long-double value exactly.

Supported rounding modes:

- round to nearest, ties to even
- downward
- upward
- toward zero

Underflow, subnormal boundaries, the normal/subnormal transition, maximum finite values, and overflow midpoints are handled explicitly.
Native compiler casts are used where SLEEF exposes IEEE binary128 directly.

The long-double exponent range must fit within binary128.

## Testing

Added a parameterized cast suite covering 72 generated cases:

- Values beyond binary64 precision
- Both Quad backend directions
- NumPy `longdouble` cast surfaces
- `safe`, `same_kind`, and `same_value`
- Normal, subnormal, underflow, and overflow boundaries
- Nearest-even halfway cases
- All four IEEE rounding modes
- Positive and negative values
- Signed zero, infinities, and NaNs
- Exponent-wide adjacent-value midpoint checks
- 256 randomized exact long-double roundtrips
- Empty, 1-D, 2-D, and 3-D arrays
- Contiguous, reversed, and unaligned storage
- Concurrent execution under `pytest-run-parallel`

## Performance

For one million elements on x86-64:

| Cast | Before | After |
|---|---:|---:|
| NumPy long double -> SLEEF | 24.5 ms | 17.5 ms |
| Quad long double -> SLEEF | 25.7 ms | 18.8 ms |
| SLEEF -> NumPy long double | 22.9 ms | 37.5 ms |
| SLEEF -> Quad long double | 28.5 ms | 46.6 ms |

Widening is faster. Correct binary128-to-x87 narrowing is slower than the old binary128-to-double-to-x87 shortcut because it retains the target's full 64-bit significand and performs the required target-format rounding.